### PR TITLE
fix: fix for azure-pipelines.yml

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -111,13 +111,21 @@ module.exports = class extends Generator {
 
     this.fs.copyTpl(
       `${this.templatePath()}/docs/*.md`,
-      `${this.destinationPath()}/docs`
+      `${this.destinationPath()}/docs`,
     );
 
     this.fs.copyTpl(
       `${this.templatePath()}/**/*.tf`,
       this.destinationRoot(),
       {},
+    );
+
+    this.fs.copyTpl(
+      this.templatePath('azure-pipelines.yml'),
+      this.destinationPath('azure-pipelines.yml'),
+      {
+        testFramework: this.answers.testFramework,
+      },
     );
 
     if (this.answers.testFramework === '1') {

--- a/generators/app/templates/azure-pipelines.yml
+++ b/generators/app/templates/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
   vmImage: 'ubuntu-latest'
 
 variables:
-- group: 'Terraform Module Variables'
+- group: 'Terraform Module Variables'<% if (testFramework == '1') { %>
 
 steps:
 - task: Go@0
@@ -38,7 +38,7 @@ steps:
     arguments: './test'
   env:
     ARM_CLIENT_SECRET: $(ARM_CLIENT_SECRET)
-
+<% } %>
 - task: Npm@1
   displayName: 'Npm Install'
   inputs:


### PR DESCRIPTION
Azure-pipelines.yml wasn't moving over when the template was processed. I also noticed that I had built the pipeline specifically for a go implementation and we decided to keep the kitchen tests in the generator. I added the logic to the pipeline yaml to only include the go steps if go was used for the testing framework.